### PR TITLE
Fix RAW Sprites

### DIFF
--- a/Sprite.cpp
+++ b/Sprite.cpp
@@ -150,13 +150,15 @@ void Sprite::Load(nmemfile &file, LPCTSTR type, int version)
 		Create(num * 64, 3, 0);
 
 		*background = 0;
-		color[0] = 11;
-		color[1] = 12;
-		color[2] = 1;
+
+		//; if we're loading RAW format, we have no sprite colours - so default them all to white
+		for (int i = 0; i < num; i++)
+		{
+			color[i] = 1;
+		}
 
 		file.read(map, len);
 	}
-
 }
 
 


### PR DESCRIPTION
There was a bug where, if you load for example .MAP data as hires sprites, the sprites would appear as "random" colours. In fact, the first 3 sprites would get colours set through the code as though the code had been copy/pasted from some MC code. Anyway, we should default all sprites to be white because we have no other colour information available!